### PR TITLE
Harmonized some discrepant text

### DIFF
--- a/appendix/userroles.md
+++ b/appendix/userroles.md
@@ -4,56 +4,56 @@ description: Appendix regarding the Preferences User Roles
 
 # User Roles
 
-There are many views (aka panes) available through the Data Browser that provide access to a wealth of functionality. However, users can sometimes feel overwhelmed by the large number of available options when accessing resources within their Pod. 
+There are many views (also known as _panes_) available through the Data Browser that provide access to a wealth of functionality. However, users can sometimes feel overwhelmed by the large number of available options when accessing resources within their Pod. 
 
 To improve the Data Browser user experience, not to mention the onboarding process for new users, the views that are displayed for a particular resource are based on the user's selected role(s):
-* Normal User. Can view all standard social views.
-* Developer. In addition to Normal User, view Data, N3, and RDF views of the data.
-* Power User. In addition to Normal User, view additional Data Browser views such as Note Pad and Meetings.
+* **Normal User** -- Can view all standard social views.
+* **Developer** -- In addition to Normal User, view Data, N3, and RDF views of the data.
+* **Power User** -- In addition to Normal User, view additional Data Browser views such as Note Pad and Meetings.
 
-By default, you are not assigned to any extra roles (i.e., Normal User). You can update your assigned roles via the [Preferences](https://github.com/solid/userguide/README.md#Preferences) page in the Dashboard. The Data Browser will use the assigned roles to determine which views are applicable for you.
+By default, you are not assigned to any extra roles (i.e., you are a _Normal User_). You can update your assigned roles via the [Preferences](https://github.com/solid/userguide/README.md#Preferences) page in the Dashboard. The Data Browser will use the assigned roles to determine which views are applicable for you.
 
-_Notes:_
-* _An exception is made to the views displayed for a given resource, if it makes sharing resources easier._
+_**Notes:**_
+* _An exception may be made to the views displayed for a given resource, if it makes sharing resources easier._
 * _Your selected role(s) are be stored in your settings which are private by default._
 
 Below is a table that documents the existing Data Browser views and the user types that are associated with them.
 
 | View Name            | Description | User Type |
 | -------------------- | ---------- | ----------- |
-| [Access Control](https://github.com/solid/userguide/blob/master/views/sharing/userguide.md) | Display/update the sharing permissions for the resource. | Normal |
-| [Basic Preferences](https://github.com/solid/userguide/README.md#Preferences) | Configure your preferences. | Normal |
-| [Chat - Long](https://github.com/solid/userguide/blob/master/views/longchat/userguide.md) | A long chat session. | Normal |
+| [Access Control](https://github.com/solid/userguide/blob/master/views/sharing/userguide.md) | Display/update the sharing permissions for the resource. | Normal User |
+| [Basic Preferences](https://github.com/solid/userguide/README.md#Preferences) | Configure your preferences. | Normal User |
+| [Chat - Long](https://github.com/solid/userguide/blob/master/views/longchat/userguide.md) | A long chat session. | Normal User |
 | [Chat - Short](https://github.com/solid/userguide/blob/master/views/chat/userguide.md) | A short chat session. | Power User |
 | Class Instance       |  | Power User |
-| [Contact](https://github.com/solid/userguide/blob/master/views/addressbook/userguide.md) | List of personal contacts. | Normal |
-| Dashboard            |  | Normal     |
-| Data Contents        | Display the resource using a Data view. | Developer  |
-| Default              |  | Normal     |
-| [Dokieli](https://dokie.li/) | Clientside editor for decentralised article publishing, annotations and social interactions. | Normal     |
-| Folder | Display the resources within the container in a tree-view. | Normal |
+| [Contact](https://github.com/solid/userguide/blob/master/views/addressbook/userguide.md) | List of personal contacts. | Normal User |
+| Dashboard            |  | Normal User |
+| Data Contents        | Display the resource using a Data view. | Developer |
+| Default              |  | Normal User |
+| [Dokieli](https://dokie.li/) | Clientside editor for decentralised article publishing, annotations and social interactions. | Normal User |
+| Folder | Display the resources within the container in a tree-view. | Normal User |
 | [Form](https://solid.github.io/solid-ui/Documentation/forms-intro.html) | Render a Form based on a Form Language model. | Power User |
-| Home                 |  | Normal     |
-| Human Readable       |  | Normal     |
-| Internal             |  | Developer  |
+| Home                 |  | Normal User |
+| Human Readable       |  | Normal User |
+| Internal             |  | Developer |
 | [Issue](https://github.com/solid/issue-pane/blob/master/README.md) | A configurable Issue tracker. | Power User |
 | [Meeting](https://github.com/solid/userguide/blob/master/views/meeting/userguide.md) | A single meeting. | Power User |
-| N3                   | Display the resource in Notation3 (N3) language. | Developer  |
+| N3                   | Display the resource in Notation3 (N3) language. | Developer |
 | [Pad](https://github.com/solid/userguide/blob/master/views/views/notepad/userguide.md) | A note pad. | Power User |
 | Playlist | An audio playlist. | Power User |
-| [Profile](https://github.com/solid/userguide/blob/master/views/profile/userguide.md) | Your public profile. | Normal     |
+| [Profile](https://github.com/solid/userguide/blob/master/views/profile/userguide.md) | Your public profile. | Normal User |
 | RDF/XML | Display the resource as RDF/XML. | Developer |
 | [Schedule](https://github.com/solid/userguide/blob/master/views/scheduledevent/userguide.md) | A scheduled meeting. | Power User |
 | Slideshow | Display a slideshow of the images contained within the container. | Power User |
-| [Social](https://github.com/solid/userguide/blob/master/views/friends/userguide.md) | Your friends. | Normal     |
-| [Source](https://github.com/solid/userguide/blob/master/views/source/userguide.md) | Display the source of a resource. | Normal |
+| [Social](https://github.com/solid/userguide/blob/master/views/friends/userguide.md) | Your friends. | Normal User |
+| [Source](https://github.com/solid/userguide/blob/master/views/source/userguide.md) | Display the source of a resource. | Normal User |
 | Tabbed               |  | Power User |
-| Table of Class       |  | Developer  |
+| Table of Class       |  | Developer |
 | Transaction          |  | Power User |
 | Transaction Period   |  | Power User |
 | Trip                 |  | Power User |
-| [Trusted Applications](https://github.com/solid/userguide#manage-your-trusted-applications) | Applications that are trusted to access your Pod. | Normal     |
+| [Trusted Applications](https://github.com/solid/userguide#manage-your-trusted-applications) | Applications that are trusted to access your Pod. | Normal User |
 | UI                   |  | Power User |
-| Video | Display videos. | Normal     |
+| Video | Display videos. | Normal User |
 
-_Tip: If you want access to some of these views, make sure to assign the proper user-type to yourself under [Preferences](https://github.com/solid/userguide/README.md#Preferences)._
+_**Tip:** If you want access to more views than a **Normal User** sees, make sure to assign the proper user-type to yourself under [Preferences](https://github.com/solid/userguide/README.md#Preferences)._


### PR DESCRIPTION
It seems strange to progress from "Normal User" to "Developer" to "Power User" ... and also it is unclear whether "Power User" includes all "Developer" views -- which would also be strange.

I would generally expect (as is the case with all other software with which I'm familiar) to progress from "Normal User" to "Power User" to "Developer", and for "Power User" views to include all "Normal User" views and "Developer" views to include all "Power User" (and thus, all "Normal User") views.

This should likely feed a new issue, as it seems likely to require changes in many areas.