### PR TITLE
Replace Normal User Role concept with Default

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,21 +168,22 @@ To display the Preferences view:
 2. Click the **Preferences** tab.
 
 #### Role
-To streamline the options presented when viewing data, you can select your role:
-* Normal User. Can view all standard social views.
-* Developer. In addition to Normal User, view Data, N3, and RDF views of the data.
-* Power User. In addition to Normal User, view additional Data Browser views such as Note Pad and Meetings.
+The options presented to you when viewing data can be customised based on your role. By default, all users can view all standard social views. Optionally, you can select one or more role(s) that provide access to advanced views in addition to the default views:
+* Developer. View Data, N3, and RDF views of the data.
+* Power User. View additional Data Browser views such as [Note Pad](https://github.com/solid/userguide/blob/master/views/views/notepad/userguide.md) and [Meeting](https://github.com/solid/userguide/blob/master/views/meeting/userguide.md).
 
 To update:
-1. Select your role(s) from the Roles listbox:
+1. Select your optional role(s) from the Roles listbox:
 
     <img src=".gitbook/assets/Roles_Listbox.png" alt="Roles listbox" width="109">
 
-    Multiple Roles can be selected by holding down the Shift or Command key on your keyboard. 
+    _**Tip:** Multiple Roles can be selected by holding down the Shift or Command key on your keyboard._
     
 2. Click off the listbox.
 
 _**Tip:** You need to refresh your web browser for the role changes to take affect._
+
+For more details on Roles, refer to the [User Roles](https://github.com/solid/userguide/blob/master/appendix/userroles.md) appendix.
 
 #### Manage your trusted applications
 

--- a/appendix/userroles.md
+++ b/appendix/userroles.md
@@ -6,54 +6,39 @@ description: Appendix regarding the Preferences User Roles
 
 There are many views (also known as _panes_) available through the Data Browser that provide access to a wealth of functionality. However, users can sometimes feel overwhelmed by the large number of available options when accessing resources within their Pod. 
 
-To improve the Data Browser user experience, not to mention the onboarding process for new users, the views that are displayed for a particular resource are based on the user's selected role(s):
-* **Normal User** -- Can view all standard social views.
-* **Developer** -- In addition to Normal User, view Data, N3, and RDF views of the data.
-* **Power User** -- In addition to Normal User, view additional Data Browser views such as Note Pad and Meetings.
-
-By default, you are not assigned to any extra roles (i.e., you are a _Normal User_). You can update your assigned roles via the [Preferences](https://github.com/solid/userguide/README.md#Preferences) page in the Dashboard. The Data Browser will use the assigned roles to determine which views are applicable for you.
+To improve the user experience, not to mention the onboarding process for new users, the Data Browser views that are displayed for a particular resource are based on the user's selected role(s). By default, all users can view all of the standard social views. Selecting one or more optional advanced role(s) (see [Roles](https://github.com/solid/userguide/blob/master/README.md#role)) enables more advanced views:
+* **Developer** -- View Data, N3, and RDF views of the data.
+* **Power User** -- View additional Data Browser views such as [Note Pad](https://github.com/solid/userguide/blob/master/views/notepad/userguide.md) and [Meeting](https://github.com/solid/userguide/blob/master/views/meeting/userguide.md).
 
 _**Notes:**_
-* _An exception may be made to the views displayed for a given resource, if it makes sharing resources easier._
+* _An exception may be made to the views displayed for a given resource if it makes sharing resources easier._
 * _Your selected role(s) are be stored in your settings which are private by default._
 
 Below is a table that documents the existing Data Browser views and the user types that are associated with them.
 
 | View Name            | Description | User Type |
-| -------------------- | ---------- | ----------- |
-| [Access Control](https://github.com/solid/userguide/blob/master/views/sharing/userguide.md) | Display/update the sharing permissions for the resource. | Normal User |
-| [Basic Preferences](https://github.com/solid/userguide/README.md#Preferences) | Configure your preferences. | Normal User |
-| [Chat - Long](https://github.com/solid/userguide/blob/master/views/longchat/userguide.md) | A long chat session. | Normal User |
-| [Chat - Short](https://github.com/solid/userguide/blob/master/views/chat/userguide.md) | A short chat session. | Power User |
-| Class Instance       |  | Power User |
-| [Contact](https://github.com/solid/userguide/blob/master/views/addressbook/userguide.md) | List of personal contacts. | Normal User |
-| Dashboard            |  | Normal User |
-| Data Contents        | Display the resource using a Data view. | Developer |
-| Default              |  | Normal User |
-| [Dokieli](https://dokie.li/) | Clientside editor for decentralised article publishing, annotations and social interactions. | Normal User |
-| Folder | Display the resources within the container in a tree-view. | Normal User |
+| - | - | - |
+| <img src="https://solid.github.io/solid-ui/src/icons/noun_99101.svg" alt="Address Book" width="16"> [Address Book](https://github.com/solid/userguide/blob/master/views/addressbook/userguide.md) | Displays a list of personal contacts. | Default |
+| [Basic Preferences](https://github.com/solid/userguide/blob/master/README.md#preferences) | Configure your preferences. | Default |
+| <img src="https://solid.github.io/solid-ui/src/icons/noun_1689339.svg" alt="Long Chat" width="16"> [Chat - Long](https://github.com/solid/userguide/blob/master/views/longchat/userguide.md) | A long chat session. | Default |
+| <img src="https://solid.github.io/solid-ui/src/icons/noun_346319.svg" alt="Chat" width="16"> [Chat - Short](https://github.com/solid/userguide/blob/master/views/chat/userguide.md) | A short chat session. Used by the [Meeting](https://github.com/solid/userguide/blob/master/views/meeting/userguide.md) view. | Power User |
+| <img src="https://solid.github.io/solid-ui/src/originalIcons/rdf_flyer.24.gif" alt="Data" width="16"> Data | Display the resource using a Data view. | Developer |
+| <img src="https://solid.github.io/solid-ui/src/icons/dokieli-logo.png" alt="Dokieli" width="16"> [Dokieli](https://dokie.li/) | Clientside editor for decentralised article publishing, annotations and social interactions. | Default |
+| <img src="https://solid.github.io/solid-ui/src/icons/noun_973694_expanded.svg" alt="Folder" width="16"> Folder | Display the resources within the container in a tree-view. | Default |
 | [Form](https://solid.github.io/solid-ui/Documentation/forms-intro.html) | Render a Form based on a Form Language model. | Power User |
-| Home                 |  | Normal User |
-| Human Readable       |  | Normal User |
-| Internal             |  | Developer |
-| [Issue](https://github.com/solid/issue-pane/blob/master/README.md) | A configurable Issue tracker. | Power User |
-| [Meeting](https://github.com/solid/userguide/blob/master/views/meeting/userguide.md) | A single meeting. | Power User |
-| N3                   | Display the resource in Notation3 (N3) language. | Developer |
-| [Pad](https://github.com/solid/userguide/blob/master/views/views/notepad/userguide.md) | A note pad. | Power User |
+| <img src="https://solid.github.io/solid-ui/src/icons/noun_547570.svg" alt="Home" width="16"> Home                 | Displays the user's Home view. | Default |
+| <img src="https://solid.github.io/solid-ui/src/icons/noun_97839.svg" alt="Issue Tracker" width="16"> [Issue Tracker](https://github.com/solid/issue-pane/blob/master/README.md) | A configurable issue tracker. | Power User |
+| <img src="https://solid.github.io/solid-ui/src/icons/noun_66617.svg" alt="Meeting" width="16"> [Meeting](https://github.com/solid/userguide/blob/master/views/meeting/userguide.md) | A single meeting. | Power User |
+| <img src="https://solid.github.io/solid-ui/src/originalIcons/w3c/n3_smaller.png" alt="Data as N3" width="16"> N3 | Display the resource in Notation3 (N3) language. | Developer |
+| <img src="https://solid.github.io/solid-ui/src/icons/noun_79217.svg" alt="Note Pad" width="16"> [Note Pad](https://github.com/solid/userguide/blob/master/views/notepad/userguide.md) | A note pad. | Power User |
 | Playlist | An audio playlist. | Power User |
-| [Profile](https://github.com/solid/userguide/blob/master/views/profile/userguide.md) | Your public profile. | Normal User |
-| RDF/XML | Display the resource as RDF/XML. | Developer |
-| [Schedule](https://github.com/solid/userguide/blob/master/views/scheduledevent/userguide.md) | A scheduled meeting. | Power User |
-| Slideshow | Display a slideshow of the images contained within the container. | Power User |
-| [Social](https://github.com/solid/userguide/blob/master/views/friends/userguide.md) | Your friends. | Normal User |
-| [Source](https://github.com/solid/userguide/blob/master/views/source/userguide.md) | Display the source of a resource. | Normal User |
-| Tabbed               |  | Power User |
-| Table of Class       |  | Developer |
-| Transaction          |  | Power User |
-| Transaction Period   |  | Power User |
-| Trip                 |  | Power User |
-| [Trusted Applications](https://github.com/solid/userguide#manage-your-trusted-applications) | Applications that are trusted to access your Pod. | Normal User |
-| UI                   |  | Power User |
-| Video | Display videos. | Normal User |
-
-_**Tip:** If you want access to more views than a **Normal User** sees, make sure to assign the proper user-type to yourself under [Preferences](https://github.com/solid/userguide/README.md#Preferences)._
+| [Profile](https://github.com/solid/userguide/blob/master/views/profile/userguide.md) | Your public profile. | Default |
+| <img src="https://solid.github.io/solid-ui/src/originalIcons/22-text-xml4.png" alt="RDF/XML" width="16"> RDF/XML | Display the resource as RDF/XML. | Developer |
+| <img src="https://solid.github.io/solid-ui/src/icons/noun_346777.svg" alt="Scheduled Event" width="16"> [Schedule](https://github.com/solid/userguide/blob/master/views/scheduledevent/userguide.md) | A scheduled event. | Power User |
+| <img src="https://solid.github.io/solid-ui/src/icons/padlock-timbl.svg" alt="Sharing" width="16"> [Sharing](https://github.com/solid/userguide/blob/master/views/sharing/userguide.md) | Display/update the sharing permissions for the resource. | Default |
+| <img src="https://solid.github.io/solid-ui/src/icons/noun_138712.svg" alt="Slideshow" width="16"> Slideshow | Display a slideshow of the images contained within the container. | Power User |
+| <img src="https://solid.github.io/solid-ui/src/originalIcons/foaf/foafTiny.gif" alt="Friends" width="16"> [Social](https://github.com/solid/userguide/blob/master/views/friends/userguide.md) | Your friends. | Default |
+| <img src="https://solid.github.io/solid-ui/src/icons/noun_109873.svg" alt="Source" width="16"> [Source](https://github.com/solid/userguide/blob/master/views/source/userguide.md) | Display the source of a resource. | Default |
+| [Trusted Applications](https://github.com/solid/userguide#manage-your-trusted-applications) | Applications that are trusted to access your Pod. | Default |
+| <img src="https://solid.github.io/solid-ui/src/originalIcons/tango/22-emblem-system.png" alt="Under the Hood" width="16"> [Under the Hood](https://github.com/solid/userguide/blob/master/views/underthehood/userguide.md) | Access 'under the hood' functionality regarding the resource. Additionally, allows you to delete a resource. | Developer |
+| Video | Display videos. | Default |


### PR DESCRIPTION
- Replaced "Normal User" with "Default" as the term "Normal User" was not used within the Data Browser.
- Cleaned up Roles text in readme.
- Linked to the User Roles appendix from the readme.
- Cleaned up text in appendix, and reset links.